### PR TITLE
Removed "Unworkable" text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,5 @@ In this repository, for V:ISSUE:LIZER you will find:
 * :x: Original tool (not available)
 * :x: A slightly modified version of the tool that is working (not available)
 
-This tool was certified as Unworkable for this project because when I tried building the tool from the source code, it hit various dependency issues which could not be resolved. Also neither the executable nor the dataset required for it was available on the Internet. 
 This repository was constructed by [Gargi Rajadhyaksha](https://github.com/gsrajadh/) under the supervision of [Emerson Murphy-Hill](https://github.com/CaptainEmerson). Thanks to Dr.Eric Knauss for his help in establishing this repository.
 


### PR DESCRIPTION
To close #4 , this update removes the text describing the repository author's attempts to get the tool working.